### PR TITLE
Introduce `runTCPServerWithSocket`

### DIFF
--- a/Network/Run/Core.hs
+++ b/Network/Run/Core.hs
@@ -26,6 +26,13 @@ openSocket :: AddrInfo -> IO Socket
 openSocket addr = socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
 #endif
 
+-- | Open socket for server use
+--
+-- The socket is configured to
+--
+-- * allow reuse of local addresses (SO_REUSEADDR)
+-- * automatically be closed during a successful @execve@ (FD_CLOEXEC)
+-- * bind to the address specified
 openServerSocket :: AddrInfo -> IO Socket
 openServerSocket addr = E.bracketOnError (openSocket addr) close $ \sock -> do
     setSocketOption sock ReuseAddr 1

--- a/Network/Run/TCP.hs
+++ b/Network/Run/TCP.hs
@@ -4,6 +4,10 @@
 module Network.Run.TCP (
     runTCPClient,
     runTCPServer,
+
+    -- * Generalized API
+    runTCPServerWithSocket,
+    openServerSocket,
 ) where
 
 import Control.Concurrent (forkFinally)
@@ -25,11 +29,29 @@ runTCPClient host port client = withSocketsDo $ do
 
 -- | Running a TCP server with an accepted socket and its peer name.
 runTCPServer :: Maybe HostName -> ServiceName -> (Socket -> IO a) -> IO a
-runTCPServer mhost port server = withSocketsDo $ do
+runTCPServer = runTCPServerWithSocket openServerSocket
+
+----------------------------------------------------------------
+-- Generalized API
+
+-- | Generalization of 'runTCPServer'
+runTCPServerWithSocket
+    :: (AddrInfo -> IO Socket)
+    -- ^ Initialize socket.
+    --
+    -- This function is called while exceptions are masked.
+    --
+    -- The default (used by 'runTCPServer') is 'openServerSocket'.
+    -> Maybe HostName
+    -> ServiceName
+    -> (Socket -> IO a)
+    -- ^ Called for each incoming connection, in a new thread
+    -> IO a
+runTCPServerWithSocket initSocket mhost port server = withSocketsDo $ do
     addr <- resolve Stream mhost port True
     E.bracket (open addr) close loop
   where
-    open addr = E.bracketOnError (openServerSocket addr) close $ \sock -> do
+    open addr = E.bracketOnError (initSocket addr) close $ \sock -> do
         listen sock 1024
         return sock
     loop sock = forever $


### PR DESCRIPTION
This introduces `runTCPServerWithSocket` as a generalization of `runTCPServer`, taking an argument that in the case of `runTCPServer` defaults to the (already existing) `openServerSocket`. This enables applications to do things like set additional socket flags or get some information about the socket that was actually created. The same generalization is applied in both `Network.Run.TCP` and `Network.Run.TCP.Timeout`.

@kazu-yamamoto By the way, it seems the `fourmolu` config used for this repo is the same one that you use for `http2-tls` and friends, but it's not present in this repo yet. I've copied it over from `http2-tls` and applied it after my PR, to make sure not to introduce formatting inconsistencies. 

This PR will be accompanied by PR against `http2-tls` that propagates this generalization.