### PR TITLE
using close instead of gclose for client

### DIFF
--- a/Network/Run/TCP.hs
+++ b/Network/Run/TCP.hs
@@ -21,7 +21,7 @@ import Network.Run.Core
 runTCPClient :: HostName -> ServiceName -> (Socket -> IO a) -> IO a
 runTCPClient host port client = withSocketsDo $ do
     addr <- resolve Stream (Just host) port [AI_ADDRCONFIG]
-    E.bracket (open addr) gclose client
+    E.bracket (open addr) close client
   where
     open addr = E.bracketOnError (openClientSocket addr) close return
 


### PR DESCRIPTION
`gclose` is important for servers but not so much for clients.
And `gclose` is visible on client commands.
So, let's use `close` for clients.