### PR TITLE
Add functions to accept socket options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for network-run
 
+## 0.3.2
+
+* Add `openServerSocketWithOptions`, `openClientSocketWithOptions`,
+  `runTCPServerWithSocketOptions`, `runTCPClientWithSocketOptions`.
+  [#6](https://github.com/kazu-yamamoto/network-run/pull/6)
+
 ## 0.3.1
 
 * Using close instead of gracefulClose for client

--- a/Network/Run/Core.hs
+++ b/Network/Run/Core.hs
@@ -5,7 +5,9 @@ module Network.Run.Core (
     resolve,
     openSocket,
     openClientSocket,
+    openClientSocketWithOptions,
     openServerSocket,
+    openServerSocketWithOptions,
     gclose,
 ) where
 
@@ -33,25 +35,41 @@ openSocket :: AddrInfo -> IO Socket
 openSocket addr = socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
 #endif
 
+-- | This is the same as
+--
+-- > openClientSocketWithOptions []
 openClientSocket :: AddrInfo -> IO Socket
-openClientSocket ai = do
+openClientSocket = openClientSocketWithOptions []
+
+openClientSocketWithOptions :: [(SocketOption, Int)] -> AddrInfo -> IO Socket
+openClientSocketWithOptions opts ai = do
     sock <- openSocket ai
+    mapM_ (uncurry $ setSocketOption sock) opts
     connect sock $ addrAddress ai
     return sock
 
 -- | Open socket for server use
 --
--- The socket is configured to
+-- This is the same as:
+--
+-- > openServerSocketWithOptions []
+openServerSocket :: AddrInfo -> IO Socket
+openServerSocket = openServerSocketWithOptions []
+
+-- | Open socket for server use, and set the provided options before binding.
+--
+-- In addition to the given options, the socket is configured to
 --
 -- * allow reuse of local addresses (SO_REUSEADDR)
 -- * automatically be closed during a successful @execve@ (FD_CLOEXEC)
 -- * bind to the address specified
-openServerSocket :: AddrInfo -> IO Socket
-openServerSocket addr = E.bracketOnError (openSocket addr) close $ \sock -> do
+openServerSocketWithOptions :: [(SocketOption, Int)] -> AddrInfo -> IO Socket
+openServerSocketWithOptions opts addr = E.bracketOnError (openSocket addr) close $ \sock -> do
     setSocketOption sock ReuseAddr 1
 #if !defined(openbsd_HOST_OS)
     when (addrFamily addr == AF_INET6) $ setSocketOption sock IPv6Only 1
 #endif
+    mapM_ (uncurry $ setSocketOption sock) opts
     withFdSocket sock $ setCloseOnExecIfNeeded
     bind sock $ addrAddress addr
     return sock

--- a/Network/Run/TCP.hs
+++ b/Network/Run/TCP.hs
@@ -6,8 +6,12 @@ module Network.Run.TCP (
     runTCPServer,
 
     -- * Generalized API
+    runTCPClientWithSocket,
+    runTCPClientWithSocketOptions,
     runTCPServerWithSocket,
+    runTCPServerWithSocketOptions,
     openServerSocket,
+    openServerSocketWithOptions,
 ) where
 
 import Control.Concurrent (forkFinally)
@@ -18,19 +22,53 @@ import Network.Socket
 import Network.Run.Core
 
 -- | Running a TCP client with a connected socket.
+--
+-- This is the same as:
+--
+-- > runTCPClientWithSocketOptions []
 runTCPClient :: HostName -> ServiceName -> (Socket -> IO a) -> IO a
-runTCPClient host port client = withSocketsDo $ do
-    addr <- resolve Stream (Just host) port [AI_ADDRCONFIG]
-    E.bracket (open addr) close client
-  where
-    open addr = E.bracketOnError (openClientSocket addr) close return
+runTCPClient = runTCPClientWithSocket openClientSocket
+
+-- | Running a TCP client with a connected socket.
+--
+-- Sets the given socket options before connecting.
+runTCPClientWithSocketOptions :: [(SocketOption, Int)] -> HostName -> ServiceName -> (Socket -> IO a) -> IO a
+runTCPClientWithSocketOptions opts = runTCPClientWithSocket (openClientSocketWithOptions opts)
 
 -- | Running a TCP server with an accepted socket and its peer name.
+--
+-- This is the same as:
+--
+-- > runTCPServerWithSocketOptions []
 runTCPServer :: Maybe HostName -> ServiceName -> (Socket -> IO a) -> IO a
 runTCPServer = runTCPServerWithSocket openServerSocket
 
+-- | Running a TCP server with an accepted socket and its peer name.
+--
+-- Sets the given socket options before binding.
+runTCPServerWithSocketOptions :: [(SocketOption, Int)] -> Maybe HostName -> ServiceName -> (Socket -> IO a) -> IO a
+runTCPServerWithSocketOptions opts = runTCPServerWithSocket (openServerSocketWithOptions opts)
+
 ----------------------------------------------------------------
 -- Generalized API
+
+-- | Generalization of 'runTCPClient'
+runTCPClientWithSocket
+    :: (AddrInfo -> IO Socket)
+    -- ^ Initialize socket.
+    --
+    -- This function is called while exceptions are masked.
+    --
+    -- The default (used by 'runTCPClient') is 'openClientSocket'.
+    -> HostName
+    -> ServiceName
+    -> (Socket -> IO a)
+    -> IO a
+runTCPClientWithSocket initSocket host port client = withSocketsDo $ do
+    addr <- resolve Stream (Just host) port [AI_ADDRCONFIG]
+    E.bracket (open addr) close client
+  where
+    open addr = E.bracketOnError (initSocket addr) close return
 
 -- | Generalization of 'runTCPServer'
 runTCPServerWithSocket

--- a/Network/Run/TCP.hs
+++ b/Network/Run/TCP.hs
@@ -6,12 +6,14 @@ module Network.Run.TCP (
     runTCPServer,
 
     -- * Generalized API
-    runTCPClientWithSocket,
-    runTCPClientWithSocketOptions,
     runTCPServerWithSocket,
     runTCPServerWithSocketOptions,
     openServerSocket,
     openServerSocketWithOptions,
+    runTCPClientWithSocket,
+    runTCPClientWithSocketOptions,
+    openClientSocket,
+    openClientSocketWithOptions,
 ) where
 
 import Control.Concurrent (forkFinally)

--- a/Network/Run/TCP/Timeout.hs
+++ b/Network/Run/TCP/Timeout.hs
@@ -3,13 +3,11 @@
 -- | Simple functions to run TCP clients and servers.
 module Network.Run.TCP.Timeout (
     runTCPServer,
-    runTCPServerWithSocketOptions,
     TimeoutServer,
 
     -- * Generalized API
     runTCPServerWithSocket,
-    openClientSocket,
-    openClientSocketWithOptions,
+    runTCPServerWithSocketOptions,
     openServerSocket,
     openServerSocketWithOptions,
 ) where

--- a/Network/Run/TCP/Timeout.hs
+++ b/Network/Run/TCP/Timeout.hs
@@ -3,12 +3,15 @@
 -- | Simple functions to run TCP clients and servers.
 module Network.Run.TCP.Timeout (
     runTCPServer,
+    runTCPServerWithSocketOptions,
     TimeoutServer,
 
     -- * Generalized API
     runTCPServerWithSocket,
     openClientSocket,
+    openClientSocketWithOptions,
     openServerSocket,
+    openServerSocketWithOptions,
 ) where
 
 import Control.Concurrent (forkFinally)
@@ -38,6 +41,19 @@ runTCPServer
     -> TimeoutServer a
     -> IO a
 runTCPServer = runTCPServerWithSocket openServerSocket
+
+-- | Running a TCP server with an accepted socket and its peer name.
+--
+-- Sets the given socket options on the socket before binding.
+runTCPServerWithSocketOptions
+    :: [(SocketOption, Int)]
+    -> Int
+    -- ^ Timeout in second.
+    -> Maybe HostName
+    -> ServiceName
+    -> TimeoutServer a
+    -> IO a
+runTCPServerWithSocketOptions opts = runTCPServerWithSocket (openServerSocketWithOptions opts)
 
 ----------------------------------------------------------------
 -- Generalized API

--- a/network-run.cabal
+++ b/network-run.cabal
@@ -1,5 +1,5 @@
 name:                network-run
-version:             0.3.1
+version:             0.3.2
 synopsis:            Simple network runner library
 description:         Simple functions to run network clients and servers.
 -- bug-reports:


### PR DESCRIPTION
Sorry @kazu-yamamoto , @FinleyMcIlwaine is currently on leave and I have no push rights to his fork of `network-run`, so I have to submit a new PR. This supersedes #6 ; it just adds one additional commit to fix up the export lists and make them more consistent.

If you put the new export lists side by side, the structure is clear:

```haskell
module Network.Run.TCP (            module Network.Run.TCP.Timeout (
    ..,                                 ..,
                                    
    -- * Generalized API                -- * Generalized API
    runTCPServerWithSocket,             runTCPServerWithSocket,
    runTCPServerWithSocketOptions,      runTCPServerWithSocketOptions,
    openServerSocket,                   openServerSocket,
    openServerSocketWithOptions,        openServerSocketWithOptions,
    runTCPClientWithSocket,           ) where
    runTCPClientWithSocketOptions,
    openClientSocket,
    openClientSocketWithOptions,
  ) where
```