### PR TITLE
Compatibility with `http2-tls`

### DIFF
--- a/Network/Run/TCP.hs
+++ b/Network/Run/TCP.hs
@@ -8,10 +8,12 @@ module Network.Run.TCP (
     runTCPServerWithSocket,
     openServerSocket,
     openServerSocketWithOptions,
+    resolve,
 
     -- * Client
     runTCPClient,
     Settings,
+    defaultSettings,
     settingsOpenClientSocket,
     runTCPClientWithSettings,
     openClientSocket,

--- a/network-run.cabal
+++ b/network-run.cabal
@@ -1,5 +1,5 @@
 name:                network-run
-version:             0.3.2
+version:             0.4.0
 synopsis:            Simple network runner library
 description:         Simple functions to run network clients and servers.
 -- bug-reports:


### PR DESCRIPTION
@kazu-yamamoto This PR (note: into `main2`) is the result of me trying the approach in `main2`, following our discussion in https://github.com/kazu-yamamoto/network-run/pull/8 .

I suspect you probably forgot to push something to `main2`, because the `main2` branch of `http2` insists on version `0.4.0`  and requires `defaultSettings`, so you probably have those changes locally. The only other change here is that we also need to export `resolve`, because since library user must now explicitly call `openServerSocket`, which takes an `AddrInfo`, the user must now also be able to call `resolve` first.

I will open another PR against `http2-tls` with some further comments.