### PR TITLE
Make sure to cancel `Handle`s

### DIFF
--- a/Network/Run/TCP/Timeout.hs
+++ b/Network/Run/TCP/Timeout.hs
@@ -60,5 +60,5 @@ runTCPServerWithSocket tm sock server = withSocketsDo $ do
                         (const $ gclose conn)
   where
     server' mgr conn = do
-        th <- T.registerKillThread mgr $ return ()
-        server mgr th conn
+        E.bracket (T.registerKillThread mgr $ return ()) T.cancel $ \th ->
+          server mgr th conn


### PR DESCRIPTION
In `Network.Run.TCP.Timeout.runTCPServerWithSocket`, we call `registerKillThread` to get a timeout `Handle`, but we weren't cancelling them. This causes `Handle`s to pile up on the heap. We now make sure to `cancel` them when the connection is finished.