### PR TITLE
Export TCP `Settings` data constructor & field accessors

### DIFF
--- a/Network/Run/TCP.hs
+++ b/Network/Run/TCP.hs
@@ -13,7 +13,7 @@ module Network.Run.TCP (
 
     -- * Client
     runTCPClient,
-    Settings,
+    Settings (..),
     defaultSettings,
     settingsOpenClientSocket,
     settingsSelectAddrInfo,


### PR DESCRIPTION
Previously, the package offered no way to construct `Settings` for the TCP client. We had `defaultSettings`, but without the field accessors, it couldn't be customized.

This PR adds the data constructor and field accessors for `Settings` to `Network.Run.TCP`'s export list (in turn making the `runTCPClientWithSettings` function much more useful!).

Thanks for your consideration!